### PR TITLE
unify card fronts 

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const { version } = createRequire(import.meta.url)('./package.json'); // some ma
 program.version(version);
 
 program
-	.addOption(new Option('-i, --input <path>', 'markdown file path').default('./README.md'))
+	.option('-i, --input <path>', 'markdown file path')
 	.addOption(new Option('-o, --output <path>', 'apkg file path').default('./output.apkg'))
 	.addOption(new Option('-n, --deck-name <name>', 'name of the deck').default('md2anki'))
 	.option('--ignore-levels <levels>', 'list of heading levels to ignore', a => a.split(',').map(b => Number(b)).filter(c => c && c >= 0 && c <= 6))

--- a/src/Card.js
+++ b/src/Card.js
@@ -3,8 +3,30 @@ export default class Card {
 		this.front = front;
 		this.back = back;
 	}
+
+	setParent(parent){
+		this.parent = parent;
+	}
+
 	get headingLevel(){
-		// the first element of the front is always the heading
+		// the first token of the front is always the heading
 		return parseInt(this.front[0].tag[1]);
+	}
+
+	get headingStr(){
+		// the second token of the front contains the complete heading
+		return this.front[1].content;
+	}
+
+	renderToHTML(md){
+		// unify heading levels for consistent look in anki
+		for(let i = 0; i < this.front.length; i++)
+			if(this.front[i].type == 'heading_open' || this.front[i].type == 'heading_close') this.front[i].tag = 'h1';
+		// render front and back to html
+		let front = md.renderer.render(this.front, md.options, {});
+		const back = md.renderer.render(this.back, md.options, {});
+		// display parent topic
+		if (this.parent) front = `<div id="front"><small>${md.render(this.parent.headingStr)}</small>${front}</div>`;
+		return { front, back };
 	}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,10 @@ export function cardsFromTokens(tokens) {
 	tokens.forEach((token, i) => {
 		// new heading starts or end of token-array reached
 		if ((token.type === 'heading_open' && !isFront) || i == tokens.length - 1) {
+			// find the 'parent' card
+			const parent = [...cards].reverse().find(c => c.headingLevel < card.headingLevel);
+			if(parent) card.setParent(parent);
+			// add finished card to array
 			cards.push(card);
 			// reset variables
 			isFront = true;
@@ -70,11 +74,12 @@ export function filterCards(cards, options) {
 
 export function deckFromCards(cards, options) {
 	// create new deck
-	const apkg = new AnkiDeck(options.deckName, { css: '' });
+	const apkg = new AnkiDeck(options.deckName, { css: '#front * {margin:0; padding:0;}' }); // ToDo: move CSS to different file
 	console.log(`deck initialized!`);
 	// add cards to deck (convert tokens to html)
 	cards.forEach((card, i) => {
-		apkg.addCard(md.renderer.render(card.front, md.options, {}), md.renderer.render(card.back, md.options, {}));
+		const { front, back } = card.renderToHTML(md);
+		apkg.addCard(front, back);
 	});
 	console.log(`added ${cards.length} cards to the deck!`);
 	return apkg;


### PR DESCRIPTION
Fronts are now always displayed as an `H1`. The parent heading (if present) is displayed above the title of the current card like shown below:

![card](https://user-images.githubusercontent.com/21085384/124397326-80cb7f00-dd0f-11eb-980d-25e8da4b767a.jpg)
