### PR TITLE
try for different paths to the hljs css 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -369,6 +369,11 @@
       "dev": true,
       "optional": true
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -420,6 +425,14 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -464,6 +477,14 @@
       "dev": true,
       "requires": {
         "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-core-module": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
+      "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
+      "requires": {
+        "has": "^1.0.3"
       }
     },
     "is-extglob": {
@@ -706,6 +727,11 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
     "pathval": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
@@ -760,6 +786,15 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
+    },
+    "resolve": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "requires": {
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"jszip": "^3.6.0",
 		"markdown-it": "^12.0.6",
 		"markdown-it-inline-comments": "^1.0.1",
+		"resolve": "^1.20.0",
 		"sha1": "^1.1.1",
 		"sql.js": "^0.5.0"
 	},

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import fs from 'fs-extra';
 import path from 'path';
+import resolve from 'resolve';
 import filedirname from 'filedirname';
 const [_, __dirname] = filedirname(new Error());
 
@@ -129,13 +130,12 @@ export function filterCards(cards, options) {
 }
 
 export function deckFromCards(cards, images, options) {
+	// get path to highlight.js cdn directory
+	let cssPath = path.dirname(resolve.sync('@highlightjs/cdn-assets/package.json', { basedir: __dirname }));
+	// construct path to highlight.js stylesheet
+	cssPath = path.resolve(cssPath, `styles/${options.codeStyle}.min.css`);
 	// load syntax-highlighting css
-	let css;
-	try{ // why can't I just import CSS like es6 modules ?!
-		css = fs.readFileSync(path.resolve(__dirname, `../../@highlightjs/cdn-assets/styles/${options.codeStyle}.min.css`),'utf8');
-	}catch(err){
-		css = fs.readFileSync(path.resolve(__dirname, `../node_modules/@highlightjs/cdn-assets/styles/${options.codeStyle}.min.css`),'utf8');
-	}
+	let css = fs.readFileSync(cssPath, 'utf8');
 	// remove comment from css, because that breaks things for some reason
 	css = css.replace(/\/\*[\s\S]*\*\//gm, '');
 	// load some more default css styles

--- a/src/index.js
+++ b/src/index.js
@@ -130,7 +130,12 @@ export function filterCards(cards, options) {
 
 export function deckFromCards(cards, images, options) {
 	// load syntax-highlighting css
-	let css = fs.readFileSync(path.resolve(__dirname, `../node_modules/@highlightjs/cdn-assets/styles/${options.codeStyle}.min.css`),'utf8');
+	let css;
+	try{ // why can't I just import CSS like es6 modules ?!
+		css = fs.readFileSync(path.resolve(__dirname, `../../@highlightjs/cdn-assets/styles/${options.codeStyle}.min.css`),'utf8');
+	}catch(err){
+		css = fs.readFileSync(path.resolve(__dirname, `../node_modules/@highlightjs/cdn-assets/styles/${options.codeStyle}.min.css`),'utf8');
+	}
 	// remove comment from css, because that breaks things for some reason
 	css = css.replace(/\/\*[\s\S]*\*\//gm, '');
 	// load some more default css styles


### PR DESCRIPTION
@RvNovae Am I allowed to call this a valid for the issue? My issue is that CSS files just cannot be imported as es6 modules and the path to `node_modules` varies on local installs compared to global ones.

I'm open to any suggestions. I know this is not the most beautiful solution, but it should fix #34.

